### PR TITLE
doc: continue config doc option updates

### DIFF
--- a/doc/reference/config-options.rst
+++ b/doc/reference/config-options.rst
@@ -3,11 +3,33 @@
 Scenario Configuration Options
 ##############################
 
-Introductory text goes here
+As explained in :ref:`acrn_configuration_tool`, ACRN scenarios define
+the hypervisor (hv) and VM settings for the execution environment of an
+ACRN-based application.  This document describes these option settings.
 
 .. contents::
    :local:
-   :depth: 3
+   :depth: 1
+
+Common option value types
+*************************
+
+Within this option documentation, we refer to some common type
+definitions:
+
+Boolean
+  A true or false value specified as either ``y`` or ``n``. Other
+  values such as ``t`` or ``f`` are not supported.
+
+Hexadecimal
+  A base-16 (integer) value represented by a leading ``0x`` or ``0X`` followed by
+  one or more characters ``0`` to ``9``, ``a`` to ``f``, or ``A`` to ``F``.
+
+Integer
+  A base-10 value represented by the characters ``0`` to ``9``.  The
+  first character must not be a ``0``. Only positive values are
+  expected.
+
 
 .. comment This configdoc.txt is generated during the doc build process
    from the acrn config schema files found in misc/acrn-config/schema

--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -51,7 +51,9 @@
          </xsl:call-template>
 
          <!-- Description of this menu / entry -->
-         <xsl:call-template name="print-annotation" />
+         <xsl:call-template name="print-annotation" >
+            <xsl:with-param name="indent" select="''" />
+         </xsl:call-template>
          <xsl:value-of select="$newline" />
          <!-- Occurence requirements -->
          <xsl:call-template name="print-occurs">
@@ -73,7 +75,9 @@
        <xsl:value-of select="$newline" />
        <!-- Print the description, type, and occurrence requirements -->
        <xsl:text>   - </xsl:text>
-       <xsl:call-template name="print-annotation" />
+       <xsl:call-template name="print-annotation" >
+          <xsl:with-param name="indent" select="'     '" />
+       </xsl:call-template>
        <xsl:choose>
          <xsl:when test="//xs:simpleType[@name=$ty]">
            <xsl:apply-templates select="//xs:simpleType[@name=$ty]" />
@@ -111,7 +115,9 @@
 
   <xsl:template match="xs:simpleType">
     <xsl:text>   - </xsl:text>
-    <xsl:call-template name="print-annotation" />
+    <xsl:call-template name="print-annotation" >
+       <xsl:with-param name="indent" select="'     '" />
+    </xsl:call-template>
   </xsl:template>
 
   <xsl:template name="print-occurs">
@@ -167,9 +173,14 @@
   </xsl:template>
 
   <xsl:template name="print-annotation">
+    <xsl:param name="indent" />
     <xsl:choose>
       <xsl:when test="xs:annotation">
-        <xsl:apply-templates select="xs:annotation" />
+<!--        <xsl:apply-templates select="xs:annotation" /> -->
+         <xsl:call-template name="printIndented">
+           <xsl:with-param name="text" select="xs:annotation/xs:documentation" />
+           <xsl:with-param name="indent" select="$indent" />
+         </xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
         <xsl:text>&lt;description is missing &gt;</xsl:text>
@@ -179,7 +190,8 @@
   </xsl:template>
 
   <xsl:template match="xs:annotation">
-    <xsl:value-of select="concat(normalize-space(xs:documentation), $newline)" />
+<!--    <xsl:value-of select="concat(normalize-space(xs:documentation), $newline)" /> -->
+    <xsl:value-of select="concat(xs:documentation, $newline)" />
   </xsl:template>
 
   <!--
@@ -223,4 +235,29 @@
     <xsl:value-of select="$newline" />
   </xsl:template>
 
+<xsl:template name="printIndented">
+  <xsl:param name="text" />
+  <xsl:param name="indent" />
+  <xsl:if test="$text">
+    <xsl:variable name="thisLine" select="substring-before($text, $newline)" />
+    <xsl:variable name="nextLine" select="substring-after($text, $newline)" />
+    <xsl:choose>
+      <xsl:when test="$thisLine or $nextLine"><!-- $text contains at least one newline -->
+        <!-- print this line -->
+        <xsl:value-of select="concat($thisLine, $newline)" />
+        <xsl:if test="substring-before(concat($nextLine, $newline), $newline)" >
+          <xsl:value-of select="$indent" />
+        </xsl:if>
+        <!-- and recurse to process the rest -->
+        <xsl:call-template name="printIndented">
+          <xsl:with-param name="text" select="$nextLine" />
+          <xsl:with-param name="indent" select="$indent" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat($text, $newline)" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:if>
+</xsl:template>
 </xsl:stylesheet>

--- a/misc/acrn-config/schema/config.xsd
+++ b/misc/acrn-config/schema/config.xsd
@@ -15,54 +15,54 @@
   <xs:all>
     <xs:element name="RELEASE" type="Boolean">
       <xs:annotation>
-	<xs:documentation>Build an image for release (``y``) or debug (``n``).
-          *We should put some information here about the differences
-          between a release and debug version.*
-        </xs:documentation>
+        <xs:documentation>Build an image for release (``y``) or debug (``n``).
+*We should put some information here about the differences
+between a release and debug version.*</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="SERIAL_CONSOLE" type="SerialConsoleOptions">
       <xs:annotation>
-	<xs:documentation>
-	  Specify the host serial device used for hypervisor debugging.
-          This option is only valid if the Service VM :ref:`vm.legacy_vuart` is
-          enabled. Leave :option:`hv.DEBUG_OPTIONS.SERIAL_CONSOLE` empty if the Service VM
-          :ref:`vm.console_vuart` is enabled. Uses
-          :option:`vm.board_private.bootargs` for the :ref:`vm.console_vuart`
-          configuration.
-	</xs:documentation>
+        <xs:documentation>Specify the host serial device used for hypervisor debugging.
+This option is only valid if the Service VM :ref:`vm.legacy_vuart` is
+enabled. Leave :option:`hv.DEBUG_OPTIONS.SERIAL_CONSOLE` empty if the
+Service VM :ref:`vm.console_vuart` is enabled. Uses
+:option:`vm.board_private.bootargs` for the :ref:`vm.console_vuart`
+configuration.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MEM_LOGLEVEL" type="LogLevelType">
       <xs:annotation>
-	<xs:documentation>Default loglevel in memory.</xs:documentation>
+        <xs:documentation>Default loglevel in memory.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="NPK_LOGLEVEL" type="LogLevelType">
       <xs:annotation>
-	<xs:documentation>Default loglevel for the hypervisor NPK log.</xs:documentation>
+        <xs:documentation>Default loglevel for the hypervisor NPK log.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="CONSOLE_LOGLEVEL" type="LogLevelType">
       <xs:annotation>
-	<xs:documentation>Default loglevel on the serial console.</xs:documentation>
+        <xs:documentation>Default loglevel on the serial console.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="LOG_DESTINATION" type="LogLevelType">
       <xs:annotation>
-	<xs:documentation>Bitmap indicating the destination of log messages.
-          Currently there are three log destinations available: bit 0 for
-          the serial console, bit 1 for the Service VM log, and bit 2
-          for the NPK log. For example, a value of ``3`` enables just the
-          serial console and Service VM logs. Effective only in debug builds (when
-          :option:`hv.DEBUG_OPTIONS.RELEASE` is ``n``).
-        </xs:documentation>
+        <xs:documentation>Bitmap indicating the destination of log messages.
+Currently there are three log destinations available:
+
+- bit 0 for the serial console (``0x1``),
+- bit 1 for the Service VM log (``0x2``), and
+- bit 2 for the NPK log (``0x4``).
+
+For example, a value of ``3`` enables only the
+serial console and Service VM logs. Effective only in debug builds (when
+:option:`hv.DEBUG_OPTIONS.RELEASE` is ``n``).</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="LOG_BUF_SIZE" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Capacity (in bytes) of logbuf for each
-          physical cpu, for example, ``0x40000``.</xs:documentation>
+        <xs:documentation>Capacity (in bytes) of logbuf for each
+physical cpu, for example, ``0x40000``.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
@@ -76,52 +76,58 @@
   <xs:all>
     <xs:element name="RELOC" type="Boolean">
       <xs:annotation>
-	<xs:documentation>Enable hypervisor relocation.</xs:documentation>
+        <xs:documentation>Specify if hypervisor relocation is enabled on booting.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="SCHEDULER" type="SchedulerType">
       <xs:annotation>
-	<xs:documentation>The CPU scheduler to be used by the hypervisor.</xs:documentation>
+        <xs:documentation>The CPU scheduler used by the hypervisor.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MULTIBOOT2" type="Boolean">
       <xs:annotation>
-	<xs:documentation>Support boot ACRN from multiboot2 protocol.</xs:documentation>
+        <xs:documentation>Specify if the ACRN hypervisor image can be booted using the
+multiboot2 protocol. If set to ``n``, GRUB's multiboot2 is not available as a
+boot option.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="RDT" type="RdtType">
       <xs:annotation>
-	<xs:documentation>Intel RDT (Resource Director Technology).</xs:documentation>
+        <xs:documentation>Enable the Intel Resource Director Technology (RDT)
+allocation feature. If the board hardware does not support
+RDT, setting this option to ``y`` is ignored.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="HYPERV_ENABLED" type="Boolean">
       <xs:annotation>
-	<xs:documentation>Enable hypervisor relocation.</xs:documentation>
+        <xs:documentation>Enable Hyper-V.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="IOMMU_ENFORCE_SNP" type="Boolean">
       <xs:annotation>
-	<xs:documentation>IOMMU enforce snoop behavior of DMA operation.</xs:documentation>
+        <xs:documentation>Specify if the IOMMU enforces snoop behavior
+of DMA operations.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="ACPI_PARSE_ENABLED" type="Boolean">
       <xs:annotation>
-	<xs:documentation>Enable ACPI runtime parsing.</xs:documentation>
+        <xs:documentation>Enable ACPI runtime parsing.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="L1D_VMENTRY_ENABLED" type="Boolean">
       <xs:annotation>
-	<xs:documentation>"Enable L1 cache flush before VM entry.</xs:documentation>
+        <xs:documentation>Enable L1 cache flush before VM entry.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MCE_ON_PSC_DISABLED" type="Boolean">
       <xs:annotation>
-	<xs:documentation>Force to disable software workaround for Machine Check Error on Page Size Change.</xs:documentation>
+        <xs:documentation>Force disabling software workaround for
+Machine Check Error on Page Size Change.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="IVSHMEM" type="IvshmemInfo">
       <xs:annotation>
-	<xs:documentation>IVSHMEM configuration.</xs:documentation>
+        <xs:documentation>Enable Inter-VM Shared memory feature.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="PSRAM" minOccurs="0" type="Boolean" />
@@ -132,37 +138,41 @@
   <xs:all>
     <xs:element name="STACK_SIZE" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Capacity of one stack, in bytes.</xs:documentation>
+        <xs:documentation>Capacity of one stack (in bytes) used by a
+physical core. Each core uses one stack for normal operation and another
+three for specific exceptions.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="HV_RAM_SIZE" type="HvRamSizeType">
       <xs:annotation>
-	<xs:documentation>Size of the RAM region used by the hypervisor.</xs:documentation>
+        <xs:documentation>Size of the RAM region used by the hypervisor.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="HV_RAM_START" type="HvRamStartType">
       <xs:annotation>
-	<xs:documentation>2M-aligned Start physical address of the RAM region used by the hypervisor.</xs:documentation>
+        <xs:documentation>The 2MB-aligned starting physical address of
+the RAM region used by the hypervisor.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="LOW_RAM_SIZE" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Size of the low RAM region.</xs:documentation>
+        <xs:documentation>Size of the low RAM region below address
+``0x10000``, starting from address ``0x0``..</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="UOS_RAM_SIZE" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Size of the User OS (UOS) RAM.</xs:documentation>
+        <xs:documentation>Size of the User VM OS RAM region.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="SOS_RAM_SIZE" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Size of the Service OS (SOS) RAM.</xs:documentation>
+        <xs:documentation>Size of the Service VM OS RAM region.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="PLATFORM_RAM_SIZE" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Size of the physical platform RAM.</xs:documentation>
+        <xs:documentation>Size of the physical platform RAM.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
@@ -170,48 +180,50 @@
 
 <xs:complexType name="capacitiesOptionsType">
   <xs:annotation>
-    <xs:documentation>Capacity limits for static assigned data struct or maximum supported resouce.</xs:documentation>
+    <xs:documentation>Capacity limits for static assigned data struct or
+maximum supported resource.</xs:documentation>
   </xs:annotation>
   <xs:all>
     <xs:element name="IOMMU_BUS_NUM" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Highest PCI bus ID used during IOMMU initialization.</xs:documentation>
+        <xs:documentation>Highest PCI bus ID used during IOMMU initialization.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_IR_ENTRIES" type="xs:integer">
       <xs:annotation>
-	<xs:documentation>Maximum number of Interrupt Remapping Entries.</xs:documentation>
+        <xs:documentation>Maximum number of Interrupt Remapping Entries.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_IOAPIC_NUM" type="MaxIoapicNumType">
       <xs:annotation>
-	<xs:documentation>Maximum number of IO-APICs.</xs:documentation>
+        <xs:documentation>Maximum number of IO-APICs.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_KATA_VM_NUM" type="xs:integer" minOccurs="0" />
     <xs:element name="MAX_PCI_DEV_NUM" type="MaxPciDevNumType">
       <xs:annotation>
-	<xs:documentation>Maximum number of PCI devices.</xs:documentation>
+        <xs:documentation>Maximum number of PCI devices.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_IOAPIC_LINES" type="MaxIoapicLinesType">
       <xs:annotation>
-	<xs:documentation>Maximum number of interrupt lines per IOAPIC.</xs:documentation>
+        <xs:documentation>Maximum number of interrupt lines per IOAPIC.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_PT_IRQ_ENTRIES" type="xs:integer">
       <xs:annotation>
-	<xs:documentation>Maximum number of interrupt source for PT devices.</xs:documentation>
+        <xs:documentation>Maximum number of interrupt source for PT devices.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_MSIX_TABLE_NUM" type="MaxMsixTableNumType">
       <xs:annotation>
-	<xs:documentation>Maximum number of MSI-X tables per device. Please leave it blank if not sure.</xs:documentation>
+        <xs:documentation>Maximum number of MSI-X tables per device.
+Leave blank if not sure.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_EMULATED_MMIO" type="MaxEmulatedMmioType">
       <xs:annotation>
-	<xs:documentation>Maximum number of emulated MMIO regions.</xs:documentation>
+        <xs:documentation>Maximum number of emulated MMIO regions.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
@@ -221,7 +233,7 @@
   <xs:all>
     <xs:element name="GPU_SBDF" type="HexFormat">
       <xs:annotation>
-	<xs:documentation>Segment, Bus, Device, and function of the GPU.</xs:documentation>
+        <xs:documentation>Segment, Bus, Device, and function of the GPU.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="UEFI_OS_LOADER_NAME" type="xs:string" minOccurs="0" />
@@ -242,27 +254,29 @@
   <xs:all>
     <xs:element name="vm_type" type="VmOptionsType">
       <xs:annotation>
-	<xs:documentation>Specify the VM type.</xs:documentation>
+        <xs:documentation>Specify the VM type.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="name" type="VmNameLimitation" minOccurs="0">
       <xs:annotation>
-	<xs:documentation>Specify the VM name which will be shown in hypervisor console command: vm_lists.</xs:documentation>
+        <xs:documentation>Specify the VM name shown in the
+hypervisor console ``vm_lists`` command.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="guest_flags" type="GuestFlagsInfo" minOccurs="0">
       <xs:annotation>
-	<xs:documentation>Select all applicable flags for the VM.</xs:documentation>
+        <xs:documentation>Select all applicable flags for the VM.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="cpu_affinity" type="CpuAffinityConfiguration" minOccurs="0">
       <xs:annotation>
-	<xs:documentation>List of pCPU that this VM's vCPUs are pinned to.</xs:documentation>
+        <xs:documentation>List of pCPU that this VM's vCPUs are pinned to.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="clos" type="ClosConfiguration">
       <xs:annotation>
-	<xs:documentation>Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.</xs:documentation>
+        <xs:documentation>Class of Service for Cache Allocation Technology.
+Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="epc_section" type="EpcSection" minOccurs="0" />
@@ -274,12 +288,12 @@
     <xs:element name="mmio_resources" type="MmioResourcesConfiguration" minOccurs="0" />
     <xs:element name="pt_intx" minOccurs="0">
       <xs:annotation>
-	<xs:documentation>pt intx mapping.</xs:documentation>
+        <xs:documentation>pt intx mapping.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="pci_devs" type="PciDevsConfiguration" minOccurs="0">
       <xs:annotation>
-	<xs:documentation>pci devices list.</xs:documentation>
+        <xs:documentation>pci devices list.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="board_private" type="BoardPrivateConfiguration" minOccurs="0" />
@@ -289,8 +303,22 @@
 
 <xs:complexType name="ACRNConfigType">
   <xs:all>
-    <xs:element name="hv" type="HvConfigType" />
-    <xs:element name="vm" type="VMConfigType" maxOccurs="unbounded" />
+    <xs:element name="hv" type="HvConfigType" >
+      <xs:annotation>
+        <xs:documentation>The hypervisor configuration defines a working scenario and target
+board by configuring the hypervisor image features and capabilities such as
+setting up the log and the serial port.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="vm" type="VMConfigType" maxOccurs="unbounded" >
+      <xs:annotation>
+        <xs:documentation>VM configuration includes **scenario-based** VM configuration
+information that is used to describe the characteristics and attributes for
+all VMs in a user scenario. It also includes **launch script-based** VM
+configuration information, where parameters are passed to the device model
+to launch post-launched User VMs.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
   <xs:attribute name="board" type="xs:string" use="required"/>
   <xs:attribute name="scenario" type="xs:string" use="required"/>

--- a/misc/acrn-config/schema/types.xsd
+++ b/misc/acrn-config/schema/types.xsd
@@ -13,8 +13,7 @@
 
 <xs:simpleType name="HexFormat">
   <xs:annotation>
-    <xs:documentation>A hexadecimal value, optionally beginning ``0x``.
-    </xs:documentation>
+    <xs:documentation>A hexadecimal value.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:pattern value="0x[0-9A-Fa-f]+|[0-9]+|0X[0-9A-Fa-f]+|[0-9]+" />
@@ -50,9 +49,8 @@
 <xs:simpleType name="MemorySizeType">
   <xs:annotation>
     <xs:documentation>Either a hexadecimal value or the string
-      ``CONFIG_SOS_RAM_SIZE`` indicating use of the Kconfig
-      :option:`CONFIG_SOS_RAM_SIZE` value.
-   </xs:documentation>
+``CONFIG_SOS_RAM_SIZE`` indicating use of the Kconfig
+:option:`CONFIG_SOS_RAM_SIZE` value.</xs:documentation>
   </xs:annotation>
   <xs:union memberTypes="SosRamSize HexFormat" />
 </xs:simpleType>
@@ -69,8 +67,20 @@
 
 <xs:simpleType name="SchedulerType">
   <xs:annotation>
-    <xs:documentation>Either ``SCHED_NOOP``, ``SCHED_IORR``, or ``SCHED_BVT``.
-     Read about the available scheduling options in :ref:`cpu_sharing`.</xs:documentation>
+    <xs:documentation>Three scheduler options are supported:
+
+- ``SCHED_NOOP``: The NOOP (No-Operation) scheduler means there is a
+  strict 1 to 1 mapping between vCPUs and pCPUs.
+- ``SCHED_IORR``: The IORR (IO sensitive Round Robin) scheduler supports
+  multipule vCPUs running on on one pCPU, scheduled by
+  a IO sensitive round robin policy.
+- ``SCHED_BVT``: The BVT (Borrowed Virtual time) scheduler is a virtual time based
+  scheduling algorithm, it dispatchs the runnable thread with the
+  earliest effective virtual time. *TODO: BVT scheduler will be built on
+  top of a prioritized scheduling mechanism, i.e. higher priority threads
+  get scheduled first, and same priority tasks are scheduled per BVT.*
+
+Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SCHED_NOOP" />
@@ -86,6 +96,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="SerialConsoleOptions">
+  <xs:annotation>
+    <xs:documentation>Either empty or a string.</xs:documentation>
+  </xs:annotation>
   <xs:union memberTypes="None SerialConsoleType" />
 </xs:simpleType>
 
@@ -96,14 +109,34 @@
 </xs:simpleType>
 
 <xs:simpleType name="IvshmemRegionType">
+  <xs:annotation>
+    <xs:documentation>Either empty or a string.</xs:documentation>
+  </xs:annotation>
   <xs:union memberTypes="None IvshmemRegionPattern" />
 
 </xs:simpleType>
 
 <xs:complexType name="IvshmemInfo">
   <xs:sequence>
-<xs:element name="IVSHMEM_ENABLED" type="Boolean"/>
-<xs:element name="IVSHMEM_REGION" type="IvshmemRegionType"/>
+   <xs:element name="IVSHMEM_ENABLED" type="Boolean">
+     <xs:annotation>
+       <xs:documentation>Enable inter-VM shared memory feature.</xs:documentation>
+     </xs:annotation>
+   </xs:element>
+   <xs:element name="IVSHMEM_REGION" type="IvshmemRegionType">
+     <xs:annotation>
+       <xs:documentation>A comma-separated list with the inter-VM shared memory region name,
+size, and VM IDs that may communicate using this shared region:
+
+* Prefix the region ``name`` with ``hv:/`` (for an hv-land solution).
+  (See :ref:`ivshmem-hld` for details.)
+* Specify the region ``size`` in MB.  Must be a power of 2, e.g., 2, 4,
+  8, 16, up to 512.
+* Specify all VM IDs that may use this shared memory area,
+  separated by a ``:``. For example, use ``0:2`` to share this area between
+  VMs 0 and 2, or ``0:1:2`` (to let VMs 0, 1, and 2 share this area).</xs:documentation>
+     </xs:annotation>
+   </xs:element>
   </xs:sequence>
 </xs:complexType>
 


### PR DESCRIPTION
Fix the configdoc.xsl to allow more complex restructuredText constructs
instead of just one paragraph.  Format for <xs:documentation> blocks
will properly output multiple text lines so features such as lists can
be used.  All multi-line content must be left-aligned unless indentation
is specifically required by rst syntax. The trailing </xs:documentation>
tag should be on the same line as the last text line.  For example:

<xs:simpleType name="SchedulerType">
  <xs:annotation>
    <xs:documentation>Three scheduler options are supported:

- ``SCHED_NOOP``: The NOOP (No-Operation) scheduler means there is a
  strict 1 to 1 mapping between vCPUs and pCPUs.
- ``SCHED_IORR``: The IORR (IO sensitive Round Robin) scheduler supports
  multipule vCPUs running on on one pCPU, scheduled by
  a IO sensitive round robin policy.
- ``SCHED_BVT``: The BVT (Borrowed Virtual time) scheduler is a virtual time based
  scheduling algorithm, it dispatchs the runnable thread with the
  earliest effective virtual time. *TODO: BVT scheduler will be built on
  top of a prioritized scheduling mechanism, i.e. higher priority threads
  get scheduled first, and same priority tasks are scheduled per BVT.*

Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:documentation>
  </xs:annotation>
  <xs:restriction base="xs:string">
    <xs:enumeration value="SCHED_NOOP" />
    <xs:enumeration value="SCHED_IORR" />
    <xs:enumeration value="SCHED_BVT" />
  </xs:restriction>
</xs:simpleType>

Added more material from the current documentation's config options and
Kconfig descriptions into the appropriate schema definition (xsd) files.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>