### PR TITLE
acrn-config: scenario schema draft fix 

### DIFF
--- a/misc/acrn-config/schema/VMtypes.xsd
+++ b/misc/acrn-config/schema/VMtypes.xsd
@@ -53,6 +53,7 @@
       </xs:annotation>
     </xs:element>
   </xs:sequence>
+  <xs:assert test="count(guest_flag) eq count(distinct-values(guest_flag))"/>
 </xs:complexType>
 
 <xs:complexType name="CpuAffinityConfiguration">

--- a/misc/acrn-config/schema/VMtypes.xsd
+++ b/misc/acrn-config/schema/VMtypes.xsd
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<xs:schema xml:id="root" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xml:id="root"
+	   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   xmlns:acrn="http://projectacrn.github.io">
 
 <xs:simpleType name="VmOptionsType">
   <xs:annotation>
@@ -74,13 +76,16 @@
 </xs:complexType>
 
 <xs:complexType name="EpcSection">
+  <xs:annotation acrn:configurable="n">
+    <xs:documentation>epc section.</xs:documentation>
+  </xs:annotation>
   <xs:sequence>
-    <xs:element name="base" type="xs:integer">
+    <xs:element name="base" type="xs:integer" default="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="size" type="xs:integer">
+    <xs:element name="size" type="xs:integer" default="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -101,13 +106,13 @@
       </xs:annotation>
     </xs:element>
     <xs:element name="start_hpa2" type="HexFormat" minOccurs="0">
-      <xs:annotation>
-        <xs:documentation>Description missing.</xs:documentation>
+      <xs:annotation acrn:configurable="n">
+        <xs:documentation>Start of second HPA for non-contiguous allocations in host for the VM.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="size_hpa2" type="MemorySizeType" minOccurs="0">
-      <xs:annotation>
-        <xs:documentation>Description missing.</xs:documentation>
+      <xs:annotation acrn:configurable="n">
+        <xs:documentation>Memory size of second HPA for non-contiguous allocations in Bytes for the VM.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:sequence>
@@ -136,8 +141,8 @@
       </xs:annotation>
     </xs:element>
     <xs:element name="bootargs" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Description missing.</xs:documentation>
+      <xs:annotation acrn:configurable="../../vm_type[starts-with(text(), 'PRE')]">
+        <xs:documentation>Configurable boot argument for pre-launched VM of hybrid or hybrid_rt mode.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="kern_load_addr" type="xs:string" minOccurs="0">
@@ -164,18 +169,18 @@
 </xs:simpleType>
 
 <xs:simpleType name="LegacyVuartType">
-  <xs:annotation>
-    <xs:documentation>Description missing.</xs:documentation>
+  <xs:annotation acrn:configurable="n">
+    <xs:documentation>vCOM type</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="VUART_LEGACY_PIO" />
-    <xs:enumeration value=" VUART_PCI" />
+    <xs:enumeration value="VUART_PCI" />
   </xs:restriction>
 </xs:simpleType>
 
 <xs:simpleType name="LegacyVuartBase">
   <xs:annotation>
-    <xs:documentation>Description missing.</xs:documentation>
+    <xs:documentation>vUART (A.K.A COM) enabling switch. Enable by exposing its base address, disable by returning INVALID_COM_BASE.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SOS_COM1_BASE" />
@@ -189,8 +194,8 @@
 </xs:simpleType>
 
 <xs:simpleType name="LegacyVuartIrq">
-  <xs:annotation>
-    <xs:documentation>Description missing.</xs:documentation>
+  <xs:annotation acrn:configurable="n">
+    <xs:documentation>vCOM irq</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SOS_COM1_IRQ" />

--- a/misc/acrn-config/schema/VMtypes.xsd
+++ b/misc/acrn-config/schema/VMtypes.xsd
@@ -53,12 +53,12 @@
       </xs:annotation>
     </xs:element>
   </xs:sequence>
-  <xs:assert test="count(guest_flag) eq count(distinct-values(guest_flag))"/>
+  <xs:assert test="count(guest_flag) eq count(distinct-values(guest_flag))" />
 </xs:complexType>
 
 <xs:complexType name="CpuAffinityConfiguration">
   <xs:sequence>
-    <xs:element name="pcpu_id" type="xs:integer" maxOccurs="unbounded">
+    <xs:element name="pcpu_id" type="xs:integer" default="2" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -68,7 +68,7 @@
 
 <xs:complexType name="ClosConfiguration">
   <xs:sequence>
-    <xs:element name="vcpu_clos" type="xs:integer" maxOccurs="unbounded">
+    <xs:element name="vcpu_clos" type="xs:integer" default="0" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -96,22 +96,22 @@
 
 <xs:complexType name="MemoryInfo">
   <xs:sequence>
-    <xs:element name="start_hpa" type="HexFormat">
+    <xs:element name="start_hpa" type="HexFormat" default="0x100000000">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="size" type="MemorySizeType">
+    <xs:element name="size" type="MemorySizeType" default="0x20000000">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="start_hpa2" type="HexFormat" minOccurs="0">
+    <xs:element name="start_hpa2" type="HexFormat" default="0x0" minOccurs="0">
       <xs:annotation acrn:configurable="n">
         <xs:documentation>Start of second HPA for non-contiguous allocations in host for the VM.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="size_hpa2" type="MemorySizeType" minOccurs="0">
+    <xs:element name="size_hpa2" type="MemorySizeType" default="0x0" minOccurs="0">
       <xs:annotation acrn:configurable="n">
         <xs:documentation>Memory size of second HPA for non-contiguous allocations in Bytes for the VM.</xs:documentation>
       </xs:annotation>
@@ -215,7 +215,7 @@
 
 <xs:complexType name="LegancyVuartConfiguration">
   <xs:sequence>
-    <xs:element name="type" type="LegacyVuartType">
+    <xs:element name="type" type="LegacyVuartType" default="VUART_LEGACY_PIO">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -230,12 +230,12 @@
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="target_vm_id" type="xs:integer" minOccurs="0">
+    <xs:element name="target_vm_id" type="xs:integer" default="1" minOccurs="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="target_uart_id" type="xs:integer" minOccurs="0">
+    <xs:element name="target_uart_id" type="xs:integer" default="1" minOccurs="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -256,18 +256,18 @@
 
 <xs:complexType name="ConsoleVuartConfiguration">
   <xs:sequence>
-    <xs:element name="base" type="PciVuartBase">
+    <xs:element name="base" type="PciVuartBase" default="INVALID_PCI_BASE">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:sequence>
-  <xs:attribute name="id" type="xs:string" use="required"/>
+  <xs:attribute name="id" type="xs:string" use="required" />
 </xs:complexType>
 
 <xs:complexType name="CommunicationVuartConfiguration">
   <xs:sequence>
-    <xs:element name="base" type="PciVuartBase">
+    <xs:element name="base" type="PciVuartBase" default="INVALID_PCI_BASE">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -283,17 +283,17 @@
       </xs:annotation>
     </xs:element>
   </xs:sequence>
-  <xs:attribute name="id" type="xs:string" use="required"/>
+  <xs:attribute name="id" type="xs:string" use="required" />
 </xs:complexType>
 
 <xs:complexType name="MmioResourcesConfiguration">
   <xs:sequence>
-    <xs:element name="TPM2" type="Boolean" minOccurs="0">
+    <xs:element name="TPM2" type="Boolean" default="n" minOccurs="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="p2sb" type="Boolean" minOccurs="0">
+    <xs:element name="p2sb" type="Boolean" default="n" minOccurs="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -303,7 +303,7 @@
 
 <xs:complexType name="PciDevsConfiguration">
   <xs:sequence>
-    <xs:element name="pci_dev" type="xs:string" maxOccurs="unbounded">
+    <xs:element name="pci_dev" type="xs:string" default="pci dev" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -313,7 +313,7 @@
 
 <xs:complexType name="BoardPrivateConfiguration">
   <xs:sequence>
-    <xs:element name="rootfs" type="xs:string">
+    <xs:element name="rootfs" type="xs:string" default="/dev/nvme0n1p3">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>

--- a/misc/acrn-config/schema/config.xsd
+++ b/misc/acrn-config/schema/config.xsd
@@ -130,7 +130,7 @@ Machine Check Error on Page Size Change.</xs:documentation>
         <xs:documentation>Enable Inter-VM Shared memory feature.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="PSRAM" minOccurs="0" type="Boolean">
+    <xs:element name="PSRAM" minOccurs="0" type="PsramInfo">
       <xs:annotation>
         <xs:documentation>Description missing</xs:documentation>
       </xs:annotation>
@@ -223,7 +223,7 @@ maximum supported resource.</xs:documentation>
         <xs:documentation>Maximum number of interrupt source for PT devices.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_MSIX_TABLE_NUM" type="MaxMsixTableNumType">
+    <xs:element name="MAX_MSIX_TABLE_NUM" type="MaxMsixTableSizeType">
       <xs:annotation>
         <xs:documentation>Maximum number of MSI-X tables per device.
 Leave blank if not sure.</xs:documentation>
@@ -322,6 +322,11 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="mmio_resources" type="MmioResourcesConfiguration" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="pci_dev_num" minOccurs="0">
       <xs:annotation>
         <xs:documentation>Description missing</xs:documentation>
       </xs:annotation>

--- a/misc/acrn-config/schema/config.xsd
+++ b/misc/acrn-config/schema/config.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <xs:schema
     xmlns:xi="http://www.w3.org/2003/XInclude"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:acrn="http://projectacrn.github.io">
 
 <xi:include href="types.xsd" xpointer="xpointer(id('root')/*)" />
 <xi:include href="HvCapacitiestypes.xsd" xpointer="xpointer(id('root')/*)" />
@@ -265,7 +266,7 @@ Leave blank if not sure.</xs:documentation>
 <xs:complexType name="VMConfigType">
   <xs:all>
     <xs:element name="vm_type" type="VmOptionsType">
-      <xs:annotation>
+      <xs:annotation acrn:readonly="y">
         <xs:documentation>Specify the VM type.</xs:documentation>
       </xs:annotation>
     </xs:element>
@@ -276,7 +277,7 @@ hypervisor console ``vm_lists`` command.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="guest_flags" type="GuestFlagsInfo" minOccurs="0">
-      <xs:annotation>
+      <xs:annotation acrn:multiselect="y">
         <xs:documentation>Select all applicable flags for the VM.</xs:documentation>
       </xs:annotation>
     </xs:element>

--- a/misc/acrn-config/schema/config.xsd
+++ b/misc/acrn-config/schema/config.xsd
@@ -14,14 +14,14 @@
   </xs:annotation>
 
   <xs:all>
-    <xs:element name="RELEASE" type="Boolean">
+    <xs:element name="RELEASE" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Build an image for release (``y``) or debug (``n``).
 *We should put some information here about the differences
 between a release and debug version.*</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="SERIAL_CONSOLE" type="SerialConsoleOptions">
+    <xs:element name="SERIAL_CONSOLE" type="SerialConsoleOptions" default="/dev/ttyS0">
       <xs:annotation>
         <xs:documentation>Specify the host serial device used for hypervisor debugging.
 This option is only valid if the Service VM :ref:`vm.legacy_vuart` is
@@ -31,22 +31,22 @@ Service VM :ref:`vm.console_vuart` is enabled. Uses
 configuration.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MEM_LOGLEVEL" type="LogLevelType">
+    <xs:element name="MEM_LOGLEVEL" type="LogLevelType" default="5">
       <xs:annotation>
         <xs:documentation>Default loglevel in memory.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="NPK_LOGLEVEL" type="LogLevelType">
+    <xs:element name="NPK_LOGLEVEL" type="LogLevelType" default="5">
       <xs:annotation>
         <xs:documentation>Default loglevel for the hypervisor NPK log.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="CONSOLE_LOGLEVEL" type="LogLevelType">
+    <xs:element name="CONSOLE_LOGLEVEL" type="LogLevelType" default="3">
       <xs:annotation>
         <xs:documentation>Default loglevel on the serial console.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="LOG_DESTINATION" type="LogLevelType">
+    <xs:element name="LOG_DESTINATION" type="LogLevelType" default="7">
       <xs:annotation>
         <xs:documentation>Bitmap indicating the destination of log messages.
 Currently there are three log destinations available:
@@ -60,7 +60,7 @@ serial console and Service VM logs. Effective only in debug builds (when
 :option:`hv.DEBUG_OPTIONS.RELEASE` is ``n``).</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="LOG_BUF_SIZE" type="HexFormat">
+    <xs:element name="LOG_BUF_SIZE" type="HexFormat" default="0x40000">
       <xs:annotation>
         <xs:documentation>Capacity (in bytes) of logbuf for each
 physical cpu, for example, ``0x40000``.</xs:documentation>
@@ -75,17 +75,17 @@ physical cpu, for example, ``0x40000``.</xs:documentation>
   </xs:annotation>
 
   <xs:all>
-    <xs:element name="RELOC" type="Boolean">
+    <xs:element name="RELOC" type="Boolean" default="y">
       <xs:annotation>
         <xs:documentation>Specify if hypervisor relocation is enabled on booting.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="SCHEDULER" type="SchedulerType">
+    <xs:element name="SCHEDULER" type="SchedulerType" default="SCHED_BVT">
       <xs:annotation>
         <xs:documentation>The CPU scheduler used by the hypervisor.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MULTIBOOT2" type="Boolean">
+    <xs:element name="MULTIBOOT2" type="Boolean" default="y">
       <xs:annotation>
         <xs:documentation>Specify if the ACRN hypervisor image can be booted using the
 multiboot2 protocol. If set to ``n``, GRUB's multiboot2 is not available as a
@@ -99,28 +99,28 @@ allocation feature. If the board hardware does not support
 RDT, setting this option to ``y`` is ignored.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="HYPERV_ENABLED" type="Boolean">
+    <xs:element name="HYPERV_ENABLED" type="Boolean" default="y">
       <xs:annotation>
         <xs:documentation>Enable Hyper-V.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="IOMMU_ENFORCE_SNP" type="Boolean">
+    <xs:element name="IOMMU_ENFORCE_SNP" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Specify if the IOMMU enforces snoop behavior
 of DMA operations.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="ACPI_PARSE_ENABLED" type="Boolean">
+    <xs:element name="ACPI_PARSE_ENABLED" type="Boolean" default="y">
       <xs:annotation>
         <xs:documentation>Enable ACPI runtime parsing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="L1D_VMENTRY_ENABLED" type="Boolean">
+    <xs:element name="L1D_VMENTRY_ENABLED" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Enable L1 cache flush before VM entry.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MCE_ON_PSC_DISABLED" type="Boolean">
+    <xs:element name="MCE_ON_PSC_DISABLED" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Force disabling software workaround for
 Machine Check Error on Page Size Change.</xs:documentation>
@@ -141,7 +141,7 @@ Machine Check Error on Page Size Change.</xs:documentation>
 
 <xs:complexType name="MemoryOptionsType">
   <xs:all>
-    <xs:element name="STACK_SIZE" type="HexFormat">
+    <xs:element name="STACK_SIZE" type="HexFormat" default="0x2000">
       <xs:annotation>
         <xs:documentation>Capacity of one stack (in bytes) used by a
 physical core. Each core uses one stack for normal operation and another
@@ -159,23 +159,23 @@ three for specific exceptions.</xs:documentation>
 the RAM region used by the hypervisor.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="LOW_RAM_SIZE" type="HexFormat">
+    <xs:element name="LOW_RAM_SIZE" type="HexFormat" default="0x00010000">
       <xs:annotation>
         <xs:documentation>Size of the low RAM region below address
 ``0x10000``, starting from address ``0x0``..</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="UOS_RAM_SIZE" type="HexFormat">
+    <xs:element name="UOS_RAM_SIZE" type="HexFormat" default="0x200000000">
       <xs:annotation>
         <xs:documentation>Size of the User VM OS RAM region.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="SOS_RAM_SIZE" type="HexFormat">
+    <xs:element name="SOS_RAM_SIZE" type="HexFormat" default="0x400000000">
       <xs:annotation>
         <xs:documentation>Size of the Service VM OS RAM region.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="PLATFORM_RAM_SIZE" type="HexFormat">
+    <xs:element name="PLATFORM_RAM_SIZE" type="HexFormat" default="0x400000000">
       <xs:annotation>
         <xs:documentation>Size of the physical platform RAM.</xs:documentation>
       </xs:annotation>
@@ -189,48 +189,48 @@ the RAM region used by the hypervisor.</xs:documentation>
 maximum supported resource.</xs:documentation>
   </xs:annotation>
   <xs:all>
-    <xs:element name="IOMMU_BUS_NUM" type="HexFormat">
+    <xs:element name="IOMMU_BUS_NUM" type="HexFormat" default="0x100">
       <xs:annotation>
         <xs:documentation>Highest PCI bus ID used during IOMMU initialization.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_IR_ENTRIES" type="xs:integer">
+    <xs:element name="MAX_IR_ENTRIES" type="xs:integer" default="256">
       <xs:annotation>
         <xs:documentation>Maximum number of Interrupt Remapping Entries.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_IOAPIC_NUM" type="MaxIoapicNumType">
+    <xs:element name="MAX_IOAPIC_NUM" type="MaxIoapicNumType" default="1">
       <xs:annotation>
         <xs:documentation>Maximum number of IO-APICs.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_KATA_VM_NUM" type="xs:integer" minOccurs="0">
+    <xs:element name="MAX_KATA_VM_NUM" type="xs:integer" minOccurs="0" default="0">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_PCI_DEV_NUM" type="MaxPciDevNumType">
+    <xs:element name="MAX_PCI_DEV_NUM" type="MaxPciDevNumType" default="96">
       <xs:annotation>
         <xs:documentation>Maximum number of PCI devices.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_IOAPIC_LINES" type="MaxIoapicLinesType">
+    <xs:element name="MAX_IOAPIC_LINES" type="MaxIoapicLinesType" default="120">
       <xs:annotation>
         <xs:documentation>Maximum number of interrupt lines per IOAPIC.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_PT_IRQ_ENTRIES" type="xs:integer">
+    <xs:element name="MAX_PT_IRQ_ENTRIES" type="xs:integer" default="256">
       <xs:annotation>
         <xs:documentation>Maximum number of interrupt source for PT devices.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_MSIX_TABLE_NUM" type="MaxMsixTableSizeType">
+    <xs:element name="MAX_MSIX_TABLE_NUM" type="MaxMsixTableSizeType" default="64">
       <xs:annotation>
         <xs:documentation>Maximum number of MSI-X tables per device.
 Leave blank if not sure.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_EMULATED_MMIO" type="MaxEmulatedMmioType">
+    <xs:element name="MAX_EMULATED_MMIO" type="MaxEmulatedMmioType" default="16">
       <xs:annotation>
         <xs:documentation>Maximum number of emulated MMIO regions.</xs:documentation>
       </xs:annotation>
@@ -240,7 +240,7 @@ Leave blank if not sure.</xs:documentation>
 
 <xs:complexType name="MiscCfgOptionsType">
   <xs:all>
-    <xs:element name="GPU_SBDF" type="HexFormat">
+    <xs:element name="GPU_SBDF" type="HexFormat" default="0x00000010">
       <xs:annotation>
         <xs:documentation>Segment, Bus, Device, and function of the GPU.</xs:documentation>
       </xs:annotation>
@@ -349,14 +349,14 @@ Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
 
 <xs:complexType name="ACRNConfigType">
   <xs:all>
-    <xs:element name="hv" type="HvConfigType" >
+    <xs:element name="hv" type="HvConfigType">
       <xs:annotation>
         <xs:documentation>The hypervisor configuration defines a working scenario and target
 board by configuring the hypervisor image features and capabilities such as
 setting up the log and the serial port.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="vm" type="VMConfigType" maxOccurs="unbounded" >
+    <xs:element name="vm" type="VMConfigType" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>VM configuration includes **scenario-based** VM configuration
 information that is used to describe the characteristics and attributes for
@@ -366,8 +366,8 @@ to launch post-launched User VMs.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
-  <xs:attribute name="board" type="xs:string" use="required"/>
-  <xs:attribute name="scenario" type="xs:string" use="required"/>
+  <xs:attribute name="board" type="xs:string" use="required" />
+  <xs:attribute name="scenario" type="xs:string" use="required" />
 </xs:complexType>
 
 <xs:element name="acrn-config" type="ACRNConfigType" />

--- a/misc/acrn-config/schema/types.xsd
+++ b/misc/acrn-config/schema/types.xsd
@@ -40,6 +40,13 @@
   <xs:union memberTypes="None HexFormat" />
 </xs:simpleType>
 
+<xs:simpleType name="MaxMsixTableSizeType">
+  <xs:annotation>
+    <xs:documentation>Either empty, or an integer value between 1 and 2048.</xs:documentation>
+  </xs:annotation>
+  <xs:union memberTypes="None MaxMsixTableNumType" />
+</xs:simpleType>
+
 <xs:simpleType name="SosRamSize">
   <xs:restriction base="xs:string">
     <xs:enumeration value="CONFIG_SOS_RAM_SIZE" />
@@ -163,7 +170,7 @@ size, and VM IDs that may communicate using this shared region:
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="CLOS_MASK" type="xs:string" maxOccurs="unbounded">
+    <xs:element name="CLOS_MASK" type="xs:string"  minOccurs="0" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -173,6 +180,12 @@ size, and VM IDs that may communicate using this shared region:
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="PsramInfo">
+  <xs:sequence>
+<xs:element name="PSRAM_ENABLED" type="Boolean"/>
   </xs:sequence>
 </xs:complexType>
 

--- a/misc/acrn-config/schema/types.xsd
+++ b/misc/acrn-config/schema/types.xsd
@@ -136,7 +136,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
 
 <xs:complexType name="IvshmemInfo">
   <xs:sequence>
-   <xs:element name="IVSHMEM_ENABLED" type="Boolean">
+   <xs:element name="IVSHMEM_ENABLED" type="Boolean" default="n">
      <xs:annotation>
        <xs:documentation>Enable inter-VM shared memory (IVSHMEM) feature.</xs:documentation>
      </xs:annotation>
@@ -160,12 +160,12 @@ size, and VM IDs that may communicate using this shared region:
 
 <xs:complexType name="RdtType">
   <xs:sequence>
-    <xs:element name="RDT_ENABLED" type="Boolean">
+    <xs:element name="RDT_ENABLED" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="CDP_ENABLED" type="Boolean">
+    <xs:element name="CDP_ENABLED" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Description missing.</xs:documentation>
       </xs:annotation>
@@ -185,7 +185,7 @@ size, and VM IDs that may communicate using this shared region:
 
 <xs:complexType name="PsramInfo">
   <xs:sequence>
-<xs:element name="PSRAM_ENABLED" type="Boolean"/>
+<xs:element name="PSRAM_ENABLED" type="Boolean" default="n" />
   </xs:sequence>
 </xs:complexType>
 


### PR DESCRIPTION
1. Relax scenario schema element constrains
2. Add readonly, configurable and multiselect attributes
3. Add guest_flag constrains so the guest_flag cannot be duplicated