### PR TITLE
doc: more config documentation updates

### DIFF
--- a/doc/reference/config-options.rst
+++ b/doc/reference/config-options.rst
@@ -9,7 +9,7 @@ ACRN-based application.  This document describes these option settings.
 
 .. contents::
    :local:
-   :depth: 1
+   :depth: 2
 
 Common option value types
 *************************

--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -55,10 +55,11 @@
             <xsl:with-param name="indent" select="''" />
          </xsl:call-template>
          <xsl:value-of select="$newline" />
-         <!-- Occurence requirements -->
+<!-- Occurence requirements (removed for now)
          <xsl:call-template name="print-occurs">
            <xsl:with-param name="name" select="@name" />
          </xsl:call-template>
+-->
           <xsl:value-of select="$newline" />
        </xsl:if>
 
@@ -93,11 +94,13 @@
            <xsl:value-of select="$newline" />
          </xsl:otherwise>
        </xsl:choose>
+<!-- removing occurs info for now
        <xsl:text>   - </xsl:text>
        <xsl:call-template name="print-occurs" >
            <xsl:with-param name="name" select="@name" />
        </xsl:call-template>
         <xsl:value-of select="$newline" />
+-->
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -122,6 +125,8 @@
 
   <xsl:template name="print-occurs">
     <xsl:param name="name" />
+  <!-- use the min/maxOccurs data to figure out if this is an optional
+       item, and how many occurrences are allowed -->
     <xsl:variable name="min">
       <xsl:choose>
         <xsl:when test="@minOccurs">
@@ -176,22 +181,16 @@
     <xsl:param name="indent" />
     <xsl:choose>
       <xsl:when test="xs:annotation">
-<!--        <xsl:apply-templates select="xs:annotation" /> -->
          <xsl:call-template name="printIndented">
            <xsl:with-param name="text" select="xs:annotation/xs:documentation" />
            <xsl:with-param name="indent" select="$indent" />
          </xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:text>&lt;description is missing &gt;</xsl:text>
+        <!-- <xsl:text>&lt;description is missing &gt;</xsl:text> -->
         <xsl:value-of select="$newline" />
       </xsl:otherwise>
     </xsl:choose>
-  </xsl:template>
-
-  <xsl:template match="xs:annotation">
-<!--    <xsl:value-of select="concat(normalize-space(xs:documentation), $newline)" /> -->
-    <xsl:value-of select="concat(xs:documentation, $newline)" />
   </xsl:template>
 
   <!--
@@ -229,7 +228,9 @@
 
   <xsl:template name="option-header">
     <xsl:param name="label" />
-
+    <!-- we're using the reST option directive for creating linkable
+         config option sections using the :option: role.  This also
+         gives us the option directive HTML formatting. -->
     <xsl:text>.. option:: </xsl:text>
     <xsl:value-of select="$label" />
     <xsl:value-of select="$newline" />
@@ -238,13 +239,17 @@
 <xsl:template name="printIndented">
   <xsl:param name="text" />
   <xsl:param name="indent" />
+  <!-- Handle multi-line documentation text and indent it properly for
+       the bullet list display we're using for node descriptions (but not for
+       heading descriptions -->
   <xsl:if test="$text">
     <xsl:variable name="thisLine" select="substring-before($text, $newline)" />
     <xsl:variable name="nextLine" select="substring-after($text, $newline)" />
     <xsl:choose>
-      <xsl:when test="$thisLine or $nextLine"><!-- $text contains at least one newline -->
-        <!-- print this line -->
+      <xsl:when test="$thisLine or $nextLine">
+        <!-- $text contains at least one newline, and there's more coming so print it -->
         <xsl:value-of select="concat($thisLine, $newline)" />
+        <!-- watch for two newlines in a row and avoid writing the indent -->
         <xsl:if test="substring-before(concat($nextLine, $newline), $newline)" >
           <xsl:value-of select="$indent" />
         </xsl:if>

--- a/misc/acrn-config/schema/HvCapacitiestypes.xsd
+++ b/misc/acrn-config/schema/HvCapacitiestypes.xsd
@@ -2,6 +2,9 @@
 <xs:schema xml:id="root" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 <xs:simpleType name="MaxIoapicNumType">
+  <xs:annotation>
+    <xs:documentation>Integer from 1 to 10.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="1" />
     <xs:maxInclusive value="10" />
@@ -9,6 +12,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="MaxPciDevNumType">
+  <xs:annotation>
+    <xs:documentation>Integer from 1 to 1024.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="1" />
     <xs:maxInclusive value="1024" />
@@ -16,6 +22,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="MaxIoapicLinesType">
+  <xs:annotation>
+    <xs:documentation>Integer from 1 to 120.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="1" />
     <xs:maxInclusive value="120" />
@@ -23,6 +32,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="MaxMsixTableNumType">
+  <xs:annotation>
+    <xs:documentation>Integer from 1 to 2048.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="1" />
     <xs:maxInclusive value="2048" />
@@ -30,6 +42,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="MaxEmulatedMmioType">
+  <xs:annotation>
+    <xs:documentation>Integer from 1 to 128.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="1" />
     <xs:maxInclusive value="128" />

--- a/misc/acrn-config/schema/VMtypes.xsd
+++ b/misc/acrn-config/schema/VMtypes.xsd
@@ -2,6 +2,9 @@
 <xs:schema xml:id="root" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 <xs:simpleType name="VmOptionsType">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SOS_VM" />
     <xs:enumeration value="SAFETY_VM" />
@@ -15,6 +18,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="VmNameLimitation">
+  <xs:annotation>
+    <xs:documentation>String from 1 to 32 characters long.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:minLength value="1" />
     <xs:maxLength value="32" />
@@ -22,6 +28,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="GuestFlagsOptionsType">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="" />
     <xs:enumeration value="0" />
@@ -36,51 +45,118 @@
 
 <xs:complexType name="GuestFlagsInfo">
   <xs:sequence>
-<xs:element name="guest_flag" type="GuestFlagsOptionsType" maxOccurs="unbounded"/>
+    <xs:element name="guest_flag" type="GuestFlagsOptionsType" maxOccurs="unbounded">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="CpuAffinityConfiguration">
   <xs:sequence>
-<xs:element name="pcpu_id" type="xs:integer" maxOccurs="unbounded"/>
+    <xs:element name="pcpu_id" type="xs:integer" maxOccurs="unbounded">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="ClosConfiguration">
   <xs:sequence>
-<xs:element name="vcpu_clos" type="xs:integer" maxOccurs="unbounded"/>
+    <xs:element name="vcpu_clos" type="xs:integer" maxOccurs="unbounded">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="EpcSection">
   <xs:sequence>
-<xs:element name="base" type="xs:integer" />
-<xs:element name="size" type="xs:integer"/>
+    <xs:element name="base" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="size" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="MemoryInfo">
   <xs:sequence>
-<xs:element name="start_hpa" type="HexFormat" />
-<xs:element name="size" type="MemorySizeType" />
-<xs:element name="start_hpa2" type="HexFormat" minOccurs="0" />
-<xs:element name="size_hpa2" type="MemorySizeType" minOccurs="0" />
+    <xs:element name="start_hpa" type="HexFormat">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="size" type="MemorySizeType">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="start_hpa2" type="HexFormat" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="size_hpa2" type="MemorySizeType" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="OsConfigurations">
   <xs:sequence>
-<xs:element name="name" type="xs:string" />
-<xs:element name="kern_type" type="VmKernelType" />
-<xs:element name="kern_mod" type="xs:string" />
-<xs:element name="ramdisk_mod" type="xs:string" />
-<xs:element name="bootargs" type="xs:string" />
-<xs:element name="kern_load_addr" type="xs:string" minOccurs="0" />
-<xs:element name="kern_entry_addr" type="xs:string" minOccurs="0" />
+    <xs:element name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="kern_type" type="VmKernelType">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="kern_mod" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="ramdisk_mod" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="bootargs" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="kern_load_addr" type="xs:string" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="kern_entry_addr" type="xs:string" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:simpleType name="VmKernelType">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="KERNEL_BZIMAGE" />
     <xs:enumeration value="KERNEL_ZEPHYR" />
@@ -88,6 +164,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="LegacyVuartType">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="VUART_LEGACY_PIO" />
     <xs:enumeration value=" VUART_PCI" />
@@ -95,6 +174,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="LegacyVuartBase">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SOS_COM1_BASE" />
     <xs:enumeration value="SOS_COM2_BASE" />
@@ -107,6 +189,9 @@
 </xs:simpleType>
 
 <xs:simpleType name="LegacyVuartIrq">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="SOS_COM1_IRQ" />
     <xs:enumeration value="SOS_COM2_IRQ" />
@@ -124,16 +209,39 @@
 
 <xs:complexType name="LegancyVuartConfiguration">
   <xs:sequence>
-<xs:element name="type" type="LegacyVuartType" />
-<xs:element name="base" type="LegacyVuartBase" />
-<xs:element name="irq" type="LegacyVuartIrq" />
-<xs:element name="target_vm_id" type="xs:integer" minOccurs="0" />
-<xs:element name="target_uart_id" type="xs:integer" minOccurs="0" />
+    <xs:element name="type" type="LegacyVuartType">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="base" type="LegacyVuartBase">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="irq" type="LegacyVuartIrq">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="target_vm_id" type="xs:integer" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="target_uart_id" type="xs:integer" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
   <xs:attribute name="id" type="xs:string" use="required"/>
 </xs:complexType>
 
 <xs:simpleType name="PciVuartBase">
+  <xs:annotation>
+    <xs:documentation>Description missing.</xs:documentation>
+  </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="PCI_VUART" />
     <xs:enumeration value="INVALID_PCI_BASE" />
@@ -142,37 +250,73 @@
 
 <xs:complexType name="ConsoleVuartConfiguration">
   <xs:sequence>
-<xs:element name="base" type="PciVuartBase" />
+    <xs:element name="base" type="PciVuartBase">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
   <xs:attribute name="id" type="xs:string" use="required"/>
 </xs:complexType>
 
 <xs:complexType name="CommunicationVuartConfiguration">
   <xs:sequence>
-<xs:element name="base" type="PciVuartBase" />
-<xs:element name="target_vm_id" type="xs:integer" />
-<xs:element name="target_uart_id" type="xs:integer" />
+    <xs:element name="base" type="PciVuartBase">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="target_vm_id" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="target_uart_id" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
   <xs:attribute name="id" type="xs:string" use="required"/>
 </xs:complexType>
 
 <xs:complexType name="MmioResourcesConfiguration">
   <xs:sequence>
-<xs:element name="TPM2" type="Boolean" minOccurs="0" />
-<xs:element name="p2sb" type="Boolean" minOccurs="0" />
+    <xs:element name="TPM2" type="Boolean" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="p2sb" type="Boolean" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="PciDevsConfiguration">
   <xs:sequence>
-<xs:element name="pci_dev" type="xs:string" maxOccurs="unbounded" />
+    <xs:element name="pci_dev" type="xs:string" maxOccurs="unbounded">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="BoardPrivateConfiguration">
   <xs:sequence>
-<xs:element name="rootfs" type="xs:string" />
-<xs:element name="bootargs" type="xs:string" />
+    <xs:element name="rootfs" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="bootargs" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 

--- a/misc/acrn-config/schema/config.xsd
+++ b/misc/acrn-config/schema/config.xsd
@@ -130,7 +130,11 @@ Machine Check Error on Page Size Change.</xs:documentation>
         <xs:documentation>Enable Inter-VM Shared memory feature.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="PSRAM" minOccurs="0" type="Boolean" />
+    <xs:element name="PSRAM" minOccurs="0" type="Boolean">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
 </xs:complexType>
 
@@ -199,7 +203,11 @@ maximum supported resource.</xs:documentation>
         <xs:documentation>Maximum number of IO-APICs.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="MAX_KATA_VM_NUM" type="xs:integer" minOccurs="0" />
+    <xs:element name="MAX_KATA_VM_NUM" type="xs:integer" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="MAX_PCI_DEV_NUM" type="MaxPciDevNumType">
       <xs:annotation>
         <xs:documentation>Maximum number of PCI devices.</xs:documentation>
@@ -236,7 +244,11 @@ Leave blank if not sure.</xs:documentation>
         <xs:documentation>Segment, Bus, Device, and function of the GPU.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="UEFI_OS_LOADER_NAME" type="xs:string" minOccurs="0" />
+    <xs:element name="UEFI_OS_LOADER_NAME" type="xs:string" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
 </xs:complexType>
 
@@ -279,13 +291,41 @@ hypervisor console ``vm_lists`` command.</xs:documentation>
 Refer SDM 17.19.2 for details, and use with caution.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="epc_section" type="EpcSection" minOccurs="0" />
-    <xs:element name="memory" type="MemoryInfo" minOccurs="0" />
-    <xs:element name="os_config" type="OsConfigurations" minOccurs="0" />
-    <xs:element name="legacy_vuart" type="LegancyVuartConfiguration" minOccurs="2" maxOccurs="2" />
-    <xs:element name="console_vuart" type="ConsoleVuartConfiguration" />
-    <xs:element name="communication_vuart" type="CommunicationVuartConfiguration" maxOccurs="unbounded" />
-    <xs:element name="mmio_resources" type="MmioResourcesConfiguration" minOccurs="0" />
+    <xs:element name="epc_section" type="EpcSection" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="memory" type="MemoryInfo" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="os_config" type="OsConfigurations" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="legacy_vuart" type="LegancyVuartConfiguration" minOccurs="2" maxOccurs="2">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="console_vuart" type="ConsoleVuartConfiguration">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="communication_vuart" type="CommunicationVuartConfiguration" maxOccurs="unbounded">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="mmio_resources" type="MmioResourcesConfiguration" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing</xs:documentation>
+      </xs:annotation>
+    </xs:element>
     <xs:element name="pt_intx" minOccurs="0">
       <xs:annotation>
         <xs:documentation>pt intx mapping.</xs:documentation>

--- a/misc/acrn-config/schema/types.xsd
+++ b/misc/acrn-config/schema/types.xsd
@@ -13,7 +13,7 @@
 
 <xs:simpleType name="HexFormat">
   <xs:annotation>
-    <xs:documentation>A hexadecimal value.</xs:documentation>
+    <xs:documentation>An integer value in hexadecimal format.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:pattern value="0x[0-9A-Fa-f]+|[0-9]+|0X[0-9A-Fa-f]+|[0-9]+" />
@@ -49,15 +49,26 @@
 <xs:simpleType name="MemorySizeType">
   <xs:annotation>
     <xs:documentation>Either a hexadecimal value or the string
-``CONFIG_SOS_RAM_SIZE`` indicating use of the Kconfig
-:option:`CONFIG_SOS_RAM_SIZE` value.</xs:documentation>
+``CONFIG_SOS_RAM_SIZE``.</xs:documentation>
   </xs:annotation>
   <xs:union memberTypes="SosRamSize HexFormat" />
 </xs:simpleType>
 
 <xs:simpleType name="LogLevelType">
   <xs:annotation>
-    <xs:documentation>An integer from 0-7.</xs:documentation>
+    <xs:documentation>An integer from 0 to 7 representing log message
+severity and intent:
+
+- 1 (LOG_FATAL) system is unusable
+- 2 (LOG_ACRN)
+- 3 (LOG_ERROR) error conditions
+- 4 (LOG_WARNING) warning conditions
+- 5 (LOG_INFO) informational
+- 6 (LOG_DEBUG) debug-level messages
+
+Note that lower values have a higher severity. Only log messages with a
+severity level higher (lower value) than a specified value will be
+recorded.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="0" />
@@ -120,7 +131,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
   <xs:sequence>
    <xs:element name="IVSHMEM_ENABLED" type="Boolean">
      <xs:annotation>
-       <xs:documentation>Enable inter-VM shared memory feature.</xs:documentation>
+       <xs:documentation>Enable inter-VM shared memory (IVSHMEM) feature.</xs:documentation>
      </xs:annotation>
    </xs:element>
    <xs:element name="IVSHMEM_REGION" type="IvshmemRegionType">
@@ -142,10 +153,26 @@ size, and VM IDs that may communicate using this shared region:
 
 <xs:complexType name="RdtType">
   <xs:sequence>
-<xs:element name="RDT_ENABLED" type="Boolean"/>
-<xs:element name="CDP_ENABLED" type="Boolean"/>
-<xs:element name="CLOS_MASK" type="xs:string" maxOccurs="unbounded" />
-<xs:element name="MBA_DELAY" type="xs:string" minOccurs="0" />
+    <xs:element name="RDT_ENABLED" type="Boolean">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="CDP_ENABLED" type="Boolean">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="CLOS_MASK" type="xs:string" maxOccurs="unbounded">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
+    <xs:element name="MBA_DELAY" type="xs:string" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Description missing.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:sequence>
 </xs:complexType>
 


### PR DESCRIPTION
Continue adding documentation about the config options into the xsl
schema definition files, including placeholders for missing
documentation.  This is still draft material that will need a good
review and update for technical accuracy and clarity, but the
infrastructure seems solid now for generating this documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>